### PR TITLE
Try marking ListLike as dontCheck for HLS

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -36,7 +36,9 @@ final: prev: {
       final.hpack
       final.stack
       final.ghcid
-      final.haskell.packages.ghc925.haskell-language-server
+      (final.haskell.packages.ghc925.haskell-language-server.overrideScope (hfinal: hprev: {
+        ListLike = final.haskell.lib.dontCheck hprev.ListLike;
+      }))
     ];
   };
 }


### PR DESCRIPTION
I took a look at this.

It looked like the actual app built correctly when I did `nix build -L`.  But I ran into the bug with the ListLike tests on GHC-9.2.5 (https://gitlab.haskell.org/ghc/ghc/-/issues/22425) when running `nix develop -L`.  Since `nix build` worked fine, my guess was that `ListLike` is a dependency of one of the development tools:

https://github.com/silky/stacklock2nix-demo-issue/blob/e59809e0218b56d0eab30286b2f06226d26018d1/nix/overlay.nix#L34-L40

I used `nix why-depends` to figure out which:

```console
$ nix develop -L --verbose
building '/nix/store/224wngixh72rr7jc6rm6yh6d5ab9pf8m-ListLike-4.7.7.drv'...
ListLike> setupCompilerEnvironmentPhase
ListLike> Build with /nix/store/625ha5v4kdpz8z8py8z57j7xy7dfd0dr-ghc-9.2.5
...
$ nix why-depends --derivation .#devShell.x86_64-linux /nix/store/224wngixh72rr7jc6rm6yh6d5ab9pf8m-ListLike-4.7.7.drv
/nix/store/s7divfq59qjlc72r8pm8xlz1psw009sm-ghc-shell-for-s2n-0.1.0.0-0.drv
└───/nix/store/9zgl9r84vz5jrlkk4ygdkbn176y14m8r-haskell-language-server-1.8.0.0.drv
    └───/nix/store/ybp2nr5wwxb43bqk2cjxmjm1rqv4zp1v-hls-fourmolu-plugin-1.1.0.0.drv
        └───/nix/store/rvid2h6spcwlgcv1ysmni8zr10jdw1sc-process-extras-0.7.4.drv
            └───/nix/store/224wngixh72rr7jc6rm6yh6d5ab9pf8m-ListLike-4.7.7.drv
```

You can see that ListLike is being pulled in by HLS.

So in this PR I disable the tests for ListLike in HLS.  This isn't actually enough to get everything compiling though, since after that I ran into various problems compiling the HLS plugins.  It may be possible to take this PR as a base, and add more overrides to HLS getting the various plugins to compile.  I'm not sure how much work that would be.

Alternatively, you could fall back to using GHC-9.2.4.  Based on the above GHC issue, this may be the safer solution:

```diff
diff --git a/nix/overlay.nix b/nix/overlay.nix
index 75a31fb..3f11604 100644
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -3,7 +3,7 @@ final: prev: {
     stackYaml = ../stack.yaml;
   };
 
-  s2n-pkg-set = final.haskell.packages.ghc925.override (oldAttrs: {
+  s2n-pkg-set = final.haskell.packages.ghc924.override (oldAttrs: {
     overrides = final.lib.composeManyExtensions [
       (oldAttrs.overrides or (_: _: {}))
 
@@ -36,7 +36,7 @@ final: prev: {
       final.hpack
       final.stack
       final.ghcid
-      final.haskell.packages.ghc925.haskell-language-server
+      final.haskell.packages.ghc924.haskell-language-server
     ];
   };
 }
```